### PR TITLE
fix: remove diverged from branch-behind check

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -114,17 +114,17 @@ runs:
             head,
           });
 
-          if (result.data.status === 'behind' || result.data.status === 'diverged') {
-            const output = `❌ The branch '${head}' is behind 'main' by ${result.data.behind_by} commit(s). Please perform git pull to merge branch with main`
+          if (result.data.status === 'behind') {
+            const output = `❌ The branch '${head}' is behind '${base}' by ${result.data.behind_by} commit(s). Please perform git pull to merge branch with ${base}`
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: output
             })
-            core.setFailed(`❌ The branch '${head}' is behind 'main' by ${result.data.behind_by} commit(s). Please perform git pull to merge branch with main`);
+            core.setFailed(`❌ The branch '${head}' is behind '${base}' by ${result.data.behind_by} commit(s). Please perform git pull to merge branch with ${base}`);
           } else {
-            console.log(`✅ The branch '${head}' is up-to-date with 'main'.`);
+            console.log(`✅ The branch '${head}' is up-to-date with '${base}'.`);
           }
 
     - name: Setup Terraform


### PR DESCRIPTION
## Context
PR #60 in whyzen_app_deploy fails `plan` CI check because staging is always 'diverged' vs prod (expected by design).

## Fix
- Remove `diverged` status from failure condition
- Replace hardcoded 'main' with actual base branch variable in error messages

This allows staging→prod merges to proceed without false positives.

## Verification
Re-run plan check on whyzen_app_deploy PR #60 after merge.